### PR TITLE
Use optparse-applicative for parsing command line arguments

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,27 +1,90 @@
-{-# LANGUAGE ViewPatterns #-}
-
 module Main where
 
-import           Data.Text              (Text)
-import qualified Data.Text.IO           as TIO
-import           Formatting             (int, sformat, (%))
-import           System.Environment     (getArgs)
+import           Control.Applicative    ((<**>))
+import           Data.List              (find, intercalate)
+import           Data.Monoid            ((<>))
+import           Options.Applicative    (Parser, ParserInfo, ReadM, action, argument, command,
+                                         completeWith, eitherReader, execParser, fullDesc, help,
+                                         helper, info, metavar, progDesc, str, subparser)
 
 import           HaskellRobot.Converter (TexConverter, toTexCwVariant, toTexTheoryMin)
 import           HaskellRobot.Runner    (TaskContext (..), generateTexFile)
 
-chooseTexConverter :: Int -> Either Text TexConverter
-chooseTexConverter 0 = Right   toTexTheoryMin
-chooseTexConverter 1 = Right $ toTexCwVariant 1
-chooseTexConverter 2 = Right $ toTexCwVariant 2
-chooseTexConverter n = Left  $ sformat ("Not known cw mode: "%int) n
+data Command =
+    Generate GenerateCommand
+
+data GenerateCommand = GenerateCommand
+    { documentType     :: GenerationType
+    , studentsFileName :: FilePath
+    , tasksFileName    :: FilePath
+    , outputFolder     :: FilePath
+    }
+
+data GenerationType = TheoryMin | Test1 | Test2
+
+generationTypes :: [(String, GenerationType)]
+generationTypes =
+    [ ("theorymin", TheoryMin)
+    , ("test1", Test1)
+    , ("test2", Test2)
+    ]
+
+documentTypeNames :: String
+documentTypeNames = intercalate ", " documentTypeNamesList
+documentTypeNamesList :: [String]
+documentTypeNamesList = fst <$> generationTypes
+
+generationType :: ReadM GenerationType
+generationType = eitherReader $ \arg ->
+                     case find (\(name, _) -> name == arg) generationTypes of
+                         Just (_, typ) -> Right typ
+                         Nothing -> Left $ "No such document type: " ++ arg ++ ", valid types are "
+                                           ++ documentTypeNames
+
+parserGenerate :: Parser GenerateCommand
+parserGenerate = GenerateCommand
+    <$> argument generationType (
+            metavar "TYPE" <> help ("type of generated document, one of " <> documentTypeNames)
+            <> completeWith documentTypeNamesList
+        )
+    <*> argument str (
+            metavar "STUDENTS_LIST_FILE" <> help "Path to a file with students list"
+            <> action "file"
+        )
+    <*> argument str (
+            metavar "TASKS_LIST_FILE" <> help "Path to a file with tasks list"
+            <> action "file"
+        )
+    <*> argument str(
+            metavar "OUTPUT_DIR" <> help "Directory where .tex file will be generated"
+            <> action "directory"
+        )
+
+parserInfoGenerate :: ParserInfo GenerateCommand
+parserInfoGenerate = info parserGenerate
+    ( fullDesc
+   <> progDesc "Generate LaTeX document of type TYPE" )
+
+parserAll :: Parser Command
+parserAll = subparser
+    (
+        command "generate" (info (Generate <$> parserGenerate) (progDesc "Generate LaTeX document"))
+    )
+
+parserInfoAll :: ParserInfo Command
+parserInfoAll = info (parserAll <**> helper)
+    ( fullDesc
+   <> progDesc "Tools for simplifying FP-course maintenance and automate teaching processes" )
+
+chooseTexConverter :: GenerationType -> TexConverter
+chooseTexConverter TheoryMin = toTexTheoryMin
+chooseTexConverter Test1     = toTexCwVariant 1
+chooseTexConverter Test2     = toTexCwVariant 2
+
+runCommand :: Command -> IO ()
+runCommand (Generate GenerateCommand{ .. }) = do
+    let converter = chooseTexConverter documentType
+    generateTexFile TaskContext{ texConverter = converter, .. }
 
 main :: IO ()
-main = do
-    -- TODO: use optparse-applicative
-    [read -> n, studentsFileName, tasksFileName, outputFolder] <- getArgs
-    let converter = chooseTexConverter n
-    either
-        TIO.putStrLn
-        (\tc -> generateTexFile TaskContext{ texConverter = tc, .. })
-        converter
+main = runCommand =<< execParser parserInfoAll

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,7 +5,7 @@ import           Data.List              (find, intercalate)
 import           Data.Monoid            ((<>))
 import           Options.Applicative    (Parser, ParserInfo, ReadM, action, argument, command,
                                          completeWith, eitherReader, execParser, fullDesc, help,
-                                         helper, info, metavar, progDesc, str, subparser)
+                                         helper, hsubparser, info, metavar, progDesc, str)
 
 import           HaskellRobot.Converter (TexConverter, toTexCwVariant, toTexTheoryMin)
 import           HaskellRobot.Runner    (TaskContext (..), generateTexFile)
@@ -66,7 +66,7 @@ parserInfoGenerate = info parserGenerate
    <> progDesc "Generate LaTeX document of type TYPE" )
 
 parserAll :: Parser Command
-parserAll = subparser
+parserAll = hsubparser
     (
         command "generate" (info (Generate <$> parserGenerate) (progDesc "Generate LaTeX document"))
     )

--- a/haskell-course-assistant.cabal
+++ b/haskell-course-assistant.cabal
@@ -49,8 +49,8 @@ executable assistant
   build-depends:       base
                      , formatting
                      , haskell-course-assistant
-                     , text
                      , optparse-applicative
+                     , text
   default-language:    Haskell2010
   default-extensions:  RecordWildCards
                      , OverloadedStrings

--- a/haskell-course-assistant.cabal
+++ b/haskell-course-assistant.cabal
@@ -22,6 +22,7 @@ library
                        , HaskellRobot.Headers.CW1
                        , HaskellRobot.Headers.CW2
 
+                       , HaskellRobot.Parsers.Common
                        , HaskellRobot.Parsers.People
                        , HaskellRobot.Parsers.Tasks
 

--- a/haskell-course-assistant.cabal
+++ b/haskell-course-assistant.cabal
@@ -50,6 +50,7 @@ executable assistant
                      , formatting
                      , haskell-course-assistant
                      , text
+                     , optparse-applicative
   default-language:    Haskell2010
   default-extensions:  RecordWildCards
                      , OverloadedStrings

--- a/src/HaskellRobot/Parsers/Common.hs
+++ b/src/HaskellRobot/Parsers/Common.hs
@@ -1,0 +1,9 @@
+module HaskellRobot.Parsers.Common
+       ( Parser
+       ) where
+
+import           Text.Megaparsec (Parsec)
+import           Data.Void       (Void)
+import           Data.Text       (Text)
+
+type Parser = Parsec Void Text

--- a/src/HaskellRobot/Parsers/People.hs
+++ b/src/HaskellRobot/Parsers/People.hs
@@ -5,12 +5,12 @@ module HaskellRobot.Parsers.People
 import           Control.Applicative              ((<|>))
 import           Data.Text                        (pack)
 
-import           Text.Megaparsec                  (char, eof, letterChar, newline,
-                                                   sepEndBy, some)
-import           Text.Megaparsec.Text             (Parser)
+import           Text.Megaparsec                  (eof, sepEndBy, some)
+import           Text.Megaparsec.Char             (char, letterChar, newline)
 
 import           HaskellRobot.Data.ReifiedStudent (ReifiedStudent (..))
 import           HaskellRobot.Data.Task           (TaskId)
+import           HaskellRobot.Parsers.Common      (Parser)
 
 studentRow :: Parser (ReifiedStudent TaskId)
 studentRow = do

--- a/src/HaskellRobot/Parsers/Tasks.hs
+++ b/src/HaskellRobot/Parsers/Tasks.hs
@@ -2,16 +2,16 @@ module HaskellRobot.Parsers.Tasks
        ( tasksParser
        ) where
 
-import           Control.Applicative    ((<|>))
-import           Data.Monoid            ((<>))
-import           Data.Text              (pack)
+import           Control.Applicative         ((<|>))
+import           Data.Monoid                 ((<>))
+import           Data.Text                   (pack)
 
-import           Text.Megaparsec        (anyChar, between, char, digitChar, letterChar,
-                                         optional, some, someTill, space, spaceChar,
-                                         string, try)
-import           Text.Megaparsec.Text   (Parser)
+import           Text.Megaparsec             (between, optional, some, someTill, try)
+import           Text.Megaparsec.Char        (anyChar, char, digitChar, letterChar,
+                                              space, spaceChar, string)
 
-import           HaskellRobot.Data.Task (TaskBlock, TaskSet)
+import           HaskellRobot.Data.Task      (TaskBlock, TaskSet)
+import           HaskellRobot.Parsers.Common (Parser)
 
 taskExampleParser :: Parser TaskSet
 taskExampleParser =

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-8.17
+resolver: lts-11.3


### PR DESCRIPTION
Resolves #2.

- Slightly changes format of arguments (introduces `generate` subcommand and human-readable document types: theorymin, test1, test2)
- `--help` option
```
Usage: assistant generate TYPE STUDENTS_LIST_FILE TASKS_LIST_FILE OUTPUT_DIR
  Generate LaTeX document

Available options:
  TYPE                     type of generated document, one of theorymin, test1,
                           test2
  STUDENTS_LIST_FILE       Path to a file with students list
  TASKS_LIST_FILE          Path to a file with tasks list
  OUTPUT_DIR               Directory where .tex file will be generated
  -h,--help                Show this help text
```
- Adds autocompletion support. Insert `source <(assistant --bash-completion-script $(which assistant))` into one of bash initialization files